### PR TITLE
Narrow range in "replace" section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "composer-plugin-api": "^1.1.0 || ^2.0"
     },
     "replace": {
-        "ocramius/package-versions": "1.2 - 1.8.99"
+        "ocramius/package-versions": "1.8.99"
     },
     "require-dev": {
         "phpunit/phpunit":          "^6.5 || ^7",


### PR DESCRIPTION
This "replace" range makes the package conflict with dependent that conflict with e.g. `"ocramius/package-versions": "<1.3"`

See https://github.com/getsentry/sentry-symfony/pull/347 for a real-world application of this issue.

This could also be considered as a bug in Composer itself since the range has a non-empty intersection with the complement of the conflicting rule. But I don't know how difficult it would be to make Composer consider this refinement.