### PR TITLE
Replace runtime warning by docblock annotation

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -45,6 +45,8 @@ use OutOfBoundsException;
  * @see \PackageVersions\Installer
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 %s
 {
@@ -160,10 +162,6 @@ PHP;
         rename($installPathTmp, $installPath);
 
         $io->write('<info>composer/package-versions-deprecated:</info> ...done generating version class');
-
-        if (version_compare(PluginInterface::PLUGIN_API_VERSION, '2.0.0', '>=')) {
-            $io->write('<info>composer/package-versions-deprecated:</info> <warning>You should rely on the Composer\InstalledVersions class instead of this package as you are using Composer 2. You can require composer-runtime-api:^2 to ensure it is present.</warning>');
-        }
     }
 
     /**

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -216,6 +216,8 @@ use OutOfBoundsException;
  * @see \PackageVersions\Installer
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 final class Versions
 {
@@ -332,6 +334,8 @@ use OutOfBoundsException;
  * @see \PackageVersions\Installer
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 final class Versions
 {
@@ -451,6 +455,8 @@ use OutOfBoundsException;
  * @see \PackageVersions\Installer
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 final class Versions
 {
@@ -863,6 +869,8 @@ use OutOfBoundsException;
  * @see \PackageVersions\Installer
  *
  * This file is overwritten at every run of `composer install` or `composer update`.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 final class Versions
 {


### PR DESCRIPTION
The runtime notice is noisy and the end-user cannot do anything about it.

I'm suggesting to replace it with a docblock annotation: this will send the deprecation message to the right target (the direct consumers of the generated class).