### PR TITLE
Document return type

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -79,6 +79,8 @@ class_exists(InstalledVersions::class);
      *
      * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
      *                                  cause any side effects here.
+     *
+     * @psalm-return key-of<self::VERSIONS>
      */
     public static function rootPackageName() : string
     {

--- a/test/PackageVersionsTest/InstallerTest.php
+++ b/test/PackageVersionsTest/InstallerTest.php
@@ -312,6 +312,8 @@ final class Versions
      *
      * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
      *                                  cause any side effects here.
+     *
+     * @psalm-return key-of<self::VERSIONS>
      */
     public static function rootPackageName() : string
     {
@@ -460,6 +462,8 @@ final class Versions
      *
      * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
      *                                  cause any side effects here.
+     *
+     * @psalm-return key-of<self::VERSIONS>
      */
     public static function rootPackageName() : string
     {
@@ -612,6 +616,8 @@ final class Versions
      *
      * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
      *                                  cause any side effects here.
+     *
+     * @psalm-return key-of<self::VERSIONS>
      */
     public static function rootPackageName() : string
     {
@@ -1055,6 +1061,8 @@ final class Versions
      *
      * @psalm-suppress ImpureMethodCall we know that {@see InstalledVersions} interaction does not
      *                                  cause any side effects here.
+     *
+     * @psalm-return key-of<self::VERSIONS>
      */
     public static function rootPackageName() : string
     {


### PR DESCRIPTION
I'm not 100% this is accurate, but in `doctrine/dbal`,

```php
        $cli = new Application('Doctrine Command Line Interface', Versions::getVersion(
            Versions::rootPackageName()
        ));
```

gives [the following error](https://github.com/doctrine/dbal/runs/1270847490?check_suite_focus=true#step:4:99) in some situations:

```
Error: Argument 1 of PackageVersions\Versions::getVersion expects string(__root__)|string(amphp/amp)|string(amphp/byte-stream)|string(composer/package-versions-deprecated)|string(composer/semver)|string(composer/xdebug-handler)|string(dnoegel/php-xdg-base-dir)|string(felixfbecker/advanced-json-rpc)|string(felixfbecker/language-server-protocol)|string(netresearch/jsonmapper)|string(nikic/php-parser)|string(openlss/lib-array2xml)|string(phpdocumentor/reflection-common)|string(phpdocumentor/reflection-docblock)|string(phpdocumentor/type-resolver)|string(psr/container)|string(psr/log)|string(sebastian/diff)|string(symfony/console)|string(symfony/polyfill-ctype)|string(symfony/polyfill-intl-grapheme)|string(symfony/polyfill-intl-normalizer)|string(symfony/polyfill-mbstring)|string(symfony/polyfill-php73)|string(symfony/polyfill-php80)|string(symfony/service-contracts)|string(symfony/string)|string(vimeo/psalm)|string(webmozart/assert)|string(webmozart/glob)|string(webmozart/path-util), parent type string provided
```