### PR TITLE
Fallback to local package version data on \Composer\InstalledVersions OutOfBoundsException

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -101,8 +101,14 @@ class_exists(InstalledVersions::class);
     public static function getVersion(string $packageName): string
     {
         if (class_exists(InstalledVersions::class, false) && (method_exists(InstalledVersions::class, 'getAllRawData') ? InstalledVersions::getAllRawData() : InstalledVersions::getRawData())) {
-            return InstalledVersions::getPrettyVersion($packageName)
-                . '@' . InstalledVersions::getReference($packageName);
+            try {
+                return InstalledVersions::getPrettyVersion($packageName)
+                    . '@' . InstalledVersions::getReference($packageName);
+            }
+            catch (OutOfBoundsException $e) {
+                // Do nothing, allow fallback to version data stored within this class
+                // Where version data does not exist an OutOfBoundsException will still be thrown
+            }
         }
 
         if (isset(self::VERSIONS[$packageName])) {

--- a/src/PackageVersions/Versions.php
+++ b/src/PackageVersions/Versions.php
@@ -65,7 +65,14 @@ final class Versions
             return $rootPackage['pretty_version'] . '@' . $rootPackage['reference'];
         }
 
-        return InstalledVersions::getPrettyVersion($packageName)
-            . '@' . InstalledVersions::getReference($packageName);
+        try {
+            return InstalledVersions::getPrettyVersion($packageName)
+              . '@' . InstalledVersions::getReference($packageName);
+        }
+        catch(OutOfBoundsException $e) {
+            // Fallback to FallbackVersions.
+            // Still throws OutOfBoundsException if package not found
+            return FallbackVersions::getVersion($packageName);
+        }
     }
 }


### PR DESCRIPTION
Addresses #27

Allows for local package version data (either compiled or through `\PackageVersions\FallbackVersions`) to be used when package version fetch from `\Composer\InstalledVersions` fails.

Where package is not installed or cannot be detected in the `InstalledVersions` class and this package an `OutOfBoundsException` will still be thrown.

The following `composer.json` can be used to test this PR.

```json
{
    "name": "composer/fallback-to-local-test",
    "type": "library",
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "composer/package-versions-deprecated",
                "version": "1.11.99.3",
                "source": {
                    "url": "git@github.com:JParkinson1991/package-versions-deprecated.git",
                    "type": "git",
                    "reference": "61c5d01e41e2a0d42c7fc6822d1835f56d4572b1"
                },
                "type": "composer-plugin",
                "require": {
                    "php":                 "^7 || ^8",
                    "composer-plugin-api": "^1.1.0 || ^2.0"
                },
                "replace": {
                    "ocramius/package-versions": "1.11.99"
                },
                "autoload": {
                    "psr-4": {
                        "PackageVersions\\": "src/PackageVersions"
                    }
                },
                "extra": {
                    "class": "PackageVersions\\Installer",
                    "branch-alias": {
                        "dev-master": "1.x-dev"
                    }
                },
                "scripts": {
                    "post-update-cmd":  "PackageVersions\\Installer::dumpVersionsClass",
                    "post-install-cmd": "PackageVersions\\Installer::dumpVersionsClass"
                }
            }
        }
    ],
    "require": {
        "composer/package-versions-deprecated": "1.11.99.3",
        "composer/composer": "^2.0",
        "vimeo/psalm": "^4.8"
    },
    "require-dev": {
    }
}
```

Testable via:

```
composer install 
./vendor/bin/psalm
# No exception..
```

``` 
composer install --no-scripts
./vendor/bin/psalm
# No exception..
```

This PR does not cause any issues with `composer/composer:^1.0`. Test composer.json can be updated with this version constraint to test that.