### PR TITLE
Fix composer v1 ClassLoader getRegisteredLoaders method missing

### DIFF
--- a/src/PackageVersions/Installer.php
+++ b/src/PackageVersions/Installer.php
@@ -127,7 +127,7 @@ class_exists(InstalledVersions::class);
             }
         } else {
             $rawData = InstalledVersions::getRawData();
-            if ($rawData === []) {
+            if ($rawData === null || $rawData === []) {
                 return false;
             }
         }

--- a/src/PackageVersions/Versions.php
+++ b/src/PackageVersions/Versions.php
@@ -82,7 +82,7 @@ final class Versions
             }
         } else {
             $rawData = InstalledVersions::getRawData();
-            if ($rawData === []) {
+            if ($rawData === null || $rawData === []) {
                 return false;
             }
         }


### PR DESCRIPTION
When using composer v1, ClassLoader is missing `getRegisteredLoaders` method, therefore the `InstalledVersions::getRawData()` can return also null in some versions. Without this check it fails with OutOfBoundsException, as the package is not installed also in case if it is installed, however the check is not possible.

Composer version 1.10.22