### PR TITLE
Add the deprecated annotation in the stub class

### DIFF
--- a/src/PackageVersions/Versions.php
+++ b/src/PackageVersions/Versions.php
@@ -17,6 +17,8 @@ class_exists(InstalledVersions::class);
  *
  * If you are reading this docBlock inside your `vendor/` dir, then this means
  * that PackageVersions didn't correctly install, and is in "fallback" mode.
+ *
+ * @deprecated in favor of the Composer\InstalledVersions class provided by Composer 2. Require composer-runtime-api:^2 to ensure it is present.
  */
 final class Versions
 {


### PR DESCRIPTION
This ensures that the class is properly marked as deprecated even when the plugin has not replaced it with the generated one.